### PR TITLE
refactor: rota de criar a causa

### DIFF
--- a/about_db/insertIntoTables.sql
+++ b/about_db/insertIntoTables.sql
@@ -108,7 +108,7 @@ INSERT INTO `labweb_project`.`negociacao`
 INSERT INTO labweb_project.causa 
 (idcausa, nome, descricao, meta, prazo, nome_arquivo_foto, status_causa, valor_arrecadado) VALUES
 ('CAU0001', 'Natal Sem Fome', 'Arrecadação de alimentos para famílias em situação de vulnerabilidade durante o período natalino', 5000.00, '2024-12-20', 'natal_sem_fome.jpg', 'CONCLUIDA', 5000),
-('CAU0002', 'Kit Escolar Solidário', 'Doação de materiais escolares para crianças de baixa renda no início do ano letivo', 3000.00, '2025-07-31', 'kit_escolar.jpg', 'CONCLUIDA', 2500),
+('CAU0002', 'Kit Escolar Solidário', 'Doação de materiais escolares para crianças de baixa renda no início do ano letivo', 3000.00, '2025-07-31', 'kit_escolar.jpg', 'ABERTA', 0.0),
 ('CAU0003', 'SOS Enchentes Bahia', 'Arrecadação emergencial para vítimas das enchentes no sul da Bahia', 10000.00, '2024-11-30', 'sos_enchentes.jpg', 'CONCLUIDA', 5000),
 ('CAU0004', 'Conectando Futuros', 'Captação de recursos para montar laboratórios de informática em escolas públicas', 15000.00, '2025-08-15', 'inclusao_digital.jpg', 'CONCLUIDA', 13000),
 ('CAU0005', 'Feira AgroSolidária', 'Financiamento coletivo para compra direta de produtores rurais familiares e doação a comunidades', 8000.00, '2024-09-30', 'feira_agro.jpg', 'CONCLUIDA', 5000);

--- a/src/main/java/com/labweb/agrodoa_backend/config/SecurityConfig.java
+++ b/src/main/java/com/labweb/agrodoa_backend/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.http.HttpMethod;
 
 import com.labweb.agrodoa_backend.service.contas.ContaDetailsService;
 
@@ -37,8 +38,9 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable()) 
             .cors(cors -> {})
             .authorizeHttpRequests(auth -> auth
+
+            //endpoints publicos
             .requestMatchers(
-                //endpoints publicos
                 "/auth/login",
                 "/usuarios/cadastrar_usuario",
                 "/anuncios?status=ativo",
@@ -52,7 +54,11 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/swagger-ui.html"
             ).permitAll()
-                .anyRequest().authenticated()
+
+            //endpoints adm
+            .requestMatchers(HttpMethod.POST, "/causas/criar_causa").hasRole("ADMINISTRADOR")
+
+            .anyRequest().authenticated()
             )
             .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //usar token em vez de session
             .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/labweb/agrodoa_backend/config/SecurityConfig.java
+++ b/src/main/java/com/labweb/agrodoa_backend/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 "/anuncios?status=ativo",
                 "/administradores", //talvez mudar para devs
                 "/causas",
+                "/causas/{idCausa}",
                 "/error",
 
                 "/v3/api-docs/**",

--- a/src/main/java/com/labweb/agrodoa_backend/controller/CausaController.java
+++ b/src/main/java/com/labweb/agrodoa_backend/controller/CausaController.java
@@ -40,7 +40,7 @@ public class CausaController {
 
 
     //Provavelmente só adm deve poder
-    @PostMapping
+    @PostMapping("/criar_causa")
     public ResponseEntity<CausaDTO> criarCausa(@RequestBody CausaDTO causaDTO) {
         
         Causa causaSalva = causaService.criarCausa(causaDTO);

--- a/src/main/java/com/labweb/agrodoa_backend/dto/CausaDTO.java
+++ b/src/main/java/com/labweb/agrodoa_backend/dto/CausaDTO.java
@@ -3,7 +3,6 @@ package com.labweb.agrodoa_backend.dto;
 import java.time.LocalDate;
 
 import com.labweb.agrodoa_backend.model.Causa;
-import com.labweb.agrodoa_backend.model.enums.StatusCausa;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,10 +22,6 @@ public class CausaDTO {
 
     private String nomeArquivoFoto;
 
-    private double valorArrecadado;
-
-    private StatusCausa status;
-
     //Construtor
     public CausaDTO(Causa causa) {
         this.nome = causa.getNome();
@@ -34,11 +29,10 @@ public class CausaDTO {
         this.meta = causa.getMeta();
         this.prazo = causa.getPrazo();
         this.nomeArquivoFoto = causa.getNomeArquivoFoto();
-        this.valorArrecadado = causa.getValorArrecadado();
-        this.status = causa.getStatus();
+        //o status e o valor arrecadado vai ser preechido por valor padrão no construtor de causa
     }
 
     public Causa transformaParaObjeto(){
-        return new Causa(nome, descricao, meta, prazo, nomeArquivoFoto, valorArrecadado);
+        return new Causa(nome, descricao, meta, prazo, nomeArquivoFoto);
     }
 }

--- a/src/main/java/com/labweb/agrodoa_backend/model/Causa.java
+++ b/src/main/java/com/labweb/agrodoa_backend/model/Causa.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -23,7 +21,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Causa {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "idcausa")
     private String idCausa;
 
@@ -49,14 +46,15 @@ public class Causa {
     @Column(name = "status_causa")
     private StatusCausa status;
    
-    public Causa(String nome, String descricao, double meta, LocalDate prazo, String nomeArquivoFoto,
-            double valorArrecadado) {
+    public Causa(String nome, String descricao, double meta, LocalDate prazo, String nomeArquivoFoto) {
         this.nome = nome;
         this.descricao = descricao;
         this.meta = meta;
         this.prazo = prazo;
         this.nomeArquivoFoto = nomeArquivoFoto;
-        this.valorArrecadado = valorArrecadado;
+
+        //valores pdrao
+        this.valorArrecadado = 0.0;
         this.status = StatusCausa.ABERTA; //valor padrao
     }
 }

--- a/src/main/java/com/labweb/agrodoa_backend/service/CausaService.java
+++ b/src/main/java/com/labweb/agrodoa_backend/service/CausaService.java
@@ -4,7 +4,8 @@ import com.labweb.agrodoa_backend.dto.CausaDTO;
 import com.labweb.agrodoa_backend.model.Causa;
 import com.labweb.agrodoa_backend.repository.CausaRepository;
 import com.labweb.agrodoa_backend.specification.CausaSpecification;
-import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -14,10 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.EntityNotFoundException; // ou outra exceção customizada
 
 @Service
-@RequiredArgsConstructor // Cria um construtor com os campos 'final' (injeção de dependência)
 public class CausaService {
 
-    private final CausaRepository causaRepository;
+    @Autowired CausaRepository causaRepo;
 
     @Transactional(readOnly = true)
     public Page<CausaDTO> buscarComFiltros(String nome, Double metaMin, Double metaMax, Pageable pageable) {
@@ -34,23 +34,23 @@ public class CausaService {
             spec = spec.and(CausaSpecification.filtrarPorMetaMax(metaMax));
         }
 
-        Page<Causa> paginaDeCausas = causaRepository.findAll(spec, pageable);
+        Page<Causa> paginaDeCausas = causaRepo.findAll(spec, pageable);
 
         return paginaDeCausas.map(CausaDTO::new); 
     }
 
     @Transactional(readOnly = true)
     public CausaDTO buscarPorId(String idCausa) {
-        return causaRepository.findById(idCausa)
+        return causaRepo.findById(idCausa)
                 .map(CausaDTO::new) 
                 .orElseThrow(() -> new EntityNotFoundException("Causa não encontrada com o ID: " + idCausa));
     }
 
     @Transactional
     public Causa criarCausa(CausaDTO causaDTO) {
-        
         Causa novaCausa = causaDTO.transformaParaObjeto();
-        Causa causaSalva = causaRepository.save(novaCausa);
+        novaCausa.setIdCausa(GeradorIdCustom.gerarIdComPrefixo("CAU", causaRepo, "idCausa"));
+        Causa causaSalva = causaRepo.saveAndFlush(novaCausa);
         
         return causaSalva; 
     }

--- a/src/main/java/com/labweb/agrodoa_backend/service/GeradorIdCustom.java
+++ b/src/main/java/com/labweb/agrodoa_backend/service/GeradorIdCustom.java
@@ -1,0 +1,39 @@
+package com.labweb.agrodoa_backend.service;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GeradorIdCustom { //pra gerar os IDs com base no nosso padrão de prefixo com 3 letras e 4 digitos
+     public static <T> String gerarIdComPrefixo(String prefixo, JpaRepository<T, String> repository, String nomeCampoId) {
+        List<T> todasEntidades = repository.findAll();
+
+        int maiorNumero = 0;
+        
+        for(T entidade: todasEntidades){
+            try{
+                Field campo = entidade.getClass().getDeclaredField(nomeCampoId);
+                campo.setAccessible(true);
+                String valorId = (String) campo.get(entidade);
+
+                if (valorId != null && valorId.startsWith(prefixo)) {
+                    String numeroStr = valorId.substring(prefixo.length());
+                    int numero = Integer.parseInt(numeroStr);
+                    if (numero > maiorNumero) {
+                        maiorNumero = numero;
+                    }
+                }
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                e.printStackTrace();
+                // log: não conseguiu acessar o campo
+            }
+        }
+
+        int proximoNumero = maiorNumero + 1;
+
+        return String.format("%s%04d", prefixo, proximoNumero);
+    }
+}


### PR DESCRIPTION
### principais alterações nesse PR
- rota de exibir causa unica adicionada nos endpoints publicos
- especificamente sobre a rota de criar causa:
  - adicionada a rotas de role do adm
  - agora funciona com um adm logado
- geração de IDs para as tabelas mudou já que a gente usa string em vez de long então não precisa mais do `@GeneratedValue(strategy = GenerationType.IDENTITY)` >> vamos usar o método estático da nova classe `GeradorIdCustom` no service
- usei `saveAndFlush` em vez de `save` pq `saveAndFlush`  força a criação sem atualizar - ent talvez `save` seja mais apropriado para editar

##
### proximos passos:
- adaptar a base dessas mesmas mudanças para usuario, principalmente a geração dos ids e a criação (cadastro)
- quando essas duas coisas referentes a usuarios estiverem ok: **MODELAR OBSERVER COM CRIAÇÃO DE CAUSA ENVIANDO EMAIL AOS USUARIOS**
- outros:
- adicionar o resto das rotas publicas e privadas nos `requestMatchers` do `SecurityConfig`